### PR TITLE
Add option to specify branch name manually

### DIFF
--- a/.github/workflows/changelog-validator.yml
+++ b/.github/workflows/changelog-validator.yml
@@ -61,8 +61,4 @@ jobs:
       - name: Validate change log entry for current branch
         if: ${{ steps.check_pre_release_branch.outputs.skip_validation == 0 }}
         run: |
-          pushd $GITHUB_WORKSPACE
-          echo "pwd = $(pwd)"
-          echo "Current branch is $(git branch --show-current), or ${{ github.ref}} according to github"
-          BRANCH_NAME=${{ github.ref }} $GITHUB_WORKSPACE/release_helpers/scripts/validateChangelogEntry.sh
-          popd
+          BRANCH_NAME=${{ github.event.pull_request.head.ref }} $GITHUB_WORKSPACE/release_helpers/scripts/validateChangelogEntry.sh

--- a/.github/workflows/changelog-validator.yml
+++ b/.github/workflows/changelog-validator.yml
@@ -61,5 +61,8 @@ jobs:
       - name: Validate change log entry for current branch
         if: ${{ steps.check_pre_release_branch.outputs.skip_validation == 0 }}
         run: |
+          pushd $GITHUB_WORKSPACE
+          echo "pwd = $(pwd)"
           echo "Current branch is $(git branch --show-current), or ${{ github.ref}} according to github"
           BRANCH_NAME=${{ github.ref }} $GITHUB_WORKSPACE/release_helpers/scripts/validateChangelogEntry.sh
+          popd

--- a/.github/workflows/changelog-validator.yml
+++ b/.github/workflows/changelog-validator.yml
@@ -30,6 +30,8 @@ jobs:
           # ${{ github.action_repository }} ends up pointing to actions/checkout@v4
           repository: Veridise/open-source-release-helpers
           path: release_helpers
+          # testing override
+          ref: a59fdf0f7a017c7948156eac47d8cb0823882520
           persist-credentials: false
 
       - name: Copy release helper Python requirements to current repo root

--- a/.github/workflows/changelog-validator.yml
+++ b/.github/workflows/changelog-validator.yml
@@ -61,4 +61,5 @@ jobs:
       - name: Validate change log entry for current branch
         if: ${{ steps.check_pre_release_branch.outputs.skip_validation == 0 }}
         run: |
+          echo "Current branch is $(git branch --show-current), or ${{ github.ref}} according to github"
           BRANCH_NAME=${{ github.ref }} $GITHUB_WORKSPACE/release_helpers/scripts/validateChangelogEntry.sh

--- a/.github/workflows/changelog-validator.yml
+++ b/.github/workflows/changelog-validator.yml
@@ -61,4 +61,4 @@ jobs:
       - name: Validate change log entry for current branch
         if: ${{ steps.check_pre_release_branch.outputs.skip_validation == 0 }}
         run: |
-          BRANCH_NAME=${{ github.event.pull_request.head.ref }} $GITHUB_WORKSPACE/release_helpers/scripts/validateChangelogEntry.sh
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}" $GITHUB_WORKSPACE/release_helpers/scripts/validateChangelogEntry.sh

--- a/.github/workflows/changelog-validator.yml
+++ b/.github/workflows/changelog-validator.yml
@@ -30,8 +30,6 @@ jobs:
           # ${{ github.action_repository }} ends up pointing to actions/checkout@v4
           repository: Veridise/open-source-release-helpers
           path: release_helpers
-          # testing override
-          ref: a59fdf0f7a017c7948156eac47d8cb0823882520
           persist-credentials: false
 
       - name: Copy release helper Python requirements to current repo root

--- a/.github/workflows/changelog-validator.yml
+++ b/.github/workflows/changelog-validator.yml
@@ -61,4 +61,4 @@ jobs:
       - name: Validate change log entry for current branch
         if: ${{ steps.check_pre_release_branch.outputs.skip_validation == 0 }}
         run: |
-          $GITHUB_WORKSPACE/release_helpers/scripts/validateChangelogEntry.sh
+          BRANCH_NAME=${{ github.ref }} $GITHUB_WORKSPACE/release_helpers/scripts/validateChangelogEntry.sh

--- a/scripts/validateChangelogEntry.sh
+++ b/scripts/validateChangelogEntry.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -x
+
 CHANGELOG_INPUT="${CHANGELOG_INPUT:-"changelogs/unreleased"}"
 CHANGELOG_APP=$(dirname "$0")/../changelog_updater/generate_changelog.py
 MDX_VALIDATOR_FOLDER=$(dirname "$0")/../mdx-validate
@@ -7,7 +9,8 @@ MDX_TEMP_FILENAME="TEST.md"
 MDX_TEMP_FILE="${MDX_VALIDATOR_FOLDER}/${MDX_TEMP_FILENAME}"
 YAML_TEMPLATE=$(dirname "$0")/template.yaml
 
-BRANCH_NAME=${BRANCH_NAME:-$(git symbolic-ref --short -q HEAD | sed -r 's/\//__/g' )}
+BRANCH_NAME=${BRANCH_NAME:-$(git branch --show-current)}
+BRANCH_NAME=$(echo "$BRANCH_NAME" | sed -r 's/\//__/g')
 CHANGELOG_FILE="${CHANGELOG_INPUT}/${BRANCH_NAME}.yaml"
 
 echo "Searching if changelog file ${CHANGELOG_FILE} exists..."

--- a/scripts/validateChangelogEntry.sh
+++ b/scripts/validateChangelogEntry.sh
@@ -10,6 +10,7 @@ MDX_TEMP_FILE="${MDX_VALIDATOR_FOLDER}/${MDX_TEMP_FILENAME}"
 YAML_TEMPLATE=$(dirname "$0")/template.yaml
 
 BRANCH_NAME=${BRANCH_NAME:-$(git branch --show-current)}
+echo "Validating changelog for branch $BRANCH_NAME..."
 BRANCH_NAME=$(echo "$BRANCH_NAME" | sed -r 's/\//__/g')
 CHANGELOG_FILE="${CHANGELOG_INPUT}/${BRANCH_NAME}.yaml"
 

--- a/scripts/validateChangelogEntry.sh
+++ b/scripts/validateChangelogEntry.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -x
-
 CHANGELOG_INPUT="${CHANGELOG_INPUT:-"changelogs/unreleased"}"
 CHANGELOG_APP=$(dirname "$0")/../changelog_updater/generate_changelog.py
 MDX_VALIDATOR_FOLDER=$(dirname "$0")/../mdx-validate

--- a/scripts/validateChangelogEntry.sh
+++ b/scripts/validateChangelogEntry.sh
@@ -7,7 +7,7 @@ MDX_TEMP_FILENAME="TEST.md"
 MDX_TEMP_FILE="${MDX_VALIDATOR_FOLDER}/${MDX_TEMP_FILENAME}"
 YAML_TEMPLATE=$(dirname "$0")/template.yaml
 
-BRANCH_NAME=$(git symbolic-ref --short -q HEAD | sed -r 's/\//__/g' )
+BRANCH_NAME=${BRANCH_NAME:-$(git symbolic-ref --short -q HEAD | sed -r 's/\//__/g' )}
 CHANGELOG_FILE="${CHANGELOG_INPUT}/${BRANCH_NAME}.yaml"
 
 echo "Searching if changelog file ${CHANGELOG_FILE} exists..."


### PR DESCRIPTION
- Fix an issue where the workflow call cannot get the branch name in the validation script
- Specify the git branch name via github context instead