### PR TITLE
upgrade actions/checkout to v6

### DIFF
--- a/.github/workflows/changelog-validator.yml
+++ b/.github/workflows/changelog-validator.yml
@@ -26,15 +26,15 @@ jobs:
 
       - name: Check out repository code
         if: ${{ steps.check_pre_release_branch.outputs.skip_validation == 0 }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Check out release helper code
         if: ${{ steps.check_pre_release_branch.outputs.skip_validation == 0 }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          # ${{ github.action_repository }} ends up pointing to actions/checkout@v4
+          # ${{ github.action_repository }} ends up pointing to actions/checkout
           repository: project-llzk/open-source-release-helpers
           path: release_helpers
           persist-credentials: false

--- a/.github/workflows/create-release-candidate.yml
+++ b/.github/workflows/create-release-candidate.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # The release bot must push the commits to satisfy the branch protection rules.
           token: ${{ secrets.RELEASE_APPROVER }}

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -11,7 +11,7 @@ jobs:
       branch: ${{ steps.branch_name.outputs.name }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -29,7 +29,7 @@ jobs:
           echo "name=$BRANCH" >> $GITHUB_OUTPUT
 
       - name: Check out repository code (pre-release branch)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.BRANCH }}
           # The release bot must push the commits to satisfy the branch protection rules.
@@ -37,9 +37,9 @@ jobs:
           persist-credentials: true
 
       - name: Check out release helper code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          # ${{ github.action_repository }} ends up pointing to actions/checkout@v4
+          # ${{ github.action_repository }} ends up pointing to actions/checkout
           repository: project-llzk/open-source-release-helpers
           path: release_helpers
           persist-credentials: false

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -27,7 +27,7 @@ jobs:
       skipped: ${{ steps.skipped.outputs.SKIPPED }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         if: github.event.pull_request.merged == false
         with:
           fetch-depth: 0
@@ -79,7 +79,7 @@ jobs:
       RELEASE_VERSION: ${{ inputs.release_version }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
           ref: ${{ inputs.checkout_from }}
@@ -93,9 +93,9 @@ jobs:
         run: echo "RELEASE_VERSION=$( echo ${GITHUB_REF_NAME} | cut -d "-" -f 1 )" >> $GITHUB_ENV
 
       - name: Check out release helper code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          # ${{ github.action_repository }} ends up pointing to actions/checkout@v4
+          # ${{ github.action_repository }} ends up pointing to actions/checkout
           repository: project-llzk/open-source-release-helpers
           path: release_helpers
           persist-credentials: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -43,7 +43,7 @@ jobs:
           echo "version=${{ env.RELEASE_VERSION }}" >> $GITHUB_OUTPUT
 
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.BRANCH }}
           fetch-depth: 0
@@ -54,9 +54,9 @@ jobs:
           persist-credentials: true
 
       - name: Check out release helper code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          # ${{ github.action_repository }} ends up pointing to actions/checkout@v4
+          # ${{ github.action_repository }} ends up pointing to actions/checkout
           repository: project-llzk/open-source-release-helpers
           path: release_helpers
           persist-credentials: false


### PR DESCRIPTION
Due to deprecation of Node 20
see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/